### PR TITLE
fix: remove height initial to avoid overflow

### DIFF
--- a/src/views/Politics.vue
+++ b/src/views/Politics.vue
@@ -137,9 +137,9 @@ import { ref } from "vue";
     align-self: center;
     flex-basis: 880px;
   }
-  @media (min-width: 1920px) {
-    height: initial;
-  }
+  // @media (min-width: 1920px) {
+  //   height: initial;
+  // }
 }
 
 .politics-img {


### PR DESCRIPTION
那行 `height: initial` 會讓 1920 的版的宣言高度過高，超過上方導覽頁
註解掉的話就會像之前設置的 `height: 100vh - 200px` 

<img width="999" alt="截圖 2023-08-16 下午12 36 34" src="https://github.com/yoshuu/tainan-candidate-vue/assets/101622223/30f3ac4c-fedc-4b70-80ba-e79d0345be78">
